### PR TITLE
Added Clipboard Buttons To Commonly Used Inputs

### DIFF
--- a/src/Clipboard.as
+++ b/src/Clipboard.as
@@ -1,0 +1,163 @@
+namespace Clipboard {
+
+    const float hueRed = 0.0;
+    const float hueGreen = 0.3;
+    const float hueBlue = 0.6;
+
+	vec3 clipboardFloat3;
+	vec3 clipboardAngles3;
+	nat3 clipboardNat3;
+	quat clipboardQuat;
+
+    void SetFloat3(vec3 pos) {
+    	clipboardFloat3 = pos;
+        print(pos);
+    }
+
+    vec3 GetFloat3() {
+    	return clipboardFloat3;
+    }
+
+    void SetAngles3(vec3 degrees) {
+    	clipboardAngles3 = degrees;
+        print(degrees);
+    }
+
+    vec3 GetAngles3() {
+    	return clipboardAngles3;
+    }
+
+    void SetNat3(nat3 pos) {
+    	clipboardNat3 = pos;
+        print(pos);
+    }
+
+    nat3 GetNat3() {
+    	return clipboardNat3;
+    }
+
+    void SetQuat(quat rot) {
+    	clipboardQuat = rot;
+        print(rot);
+    }
+
+    quat GetQuat() {
+    	return clipboardQuat;
+    }
+
+    vec3 AddCopyPasteFloat3(const string &in label, vec3 val) {
+
+        UI::PushID(label);
+        UI::PushID("Float3");
+
+        UI::SameLine();
+        if (UI::Button("Copy")) {
+            Clipboard::SetFloat3(val);
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pX", hueRed)) {
+            val.x = Clipboard::GetFloat3().x;
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pY", hueGreen)) {
+            val.y = Clipboard::GetFloat3().y;
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pZ", hueBlue)) {
+            val.z = Clipboard::GetFloat3().z;
+        }
+
+        UI::PopID();
+        UI::PopID();
+
+        return val;
+    }
+
+    vec3 AddCopyPasteAngles3(const string &in label, vec3 degrees) {
+
+        UI::PushID(label);
+        UI::PushID("Angles3");
+    	
+        UI::SameLine();
+        if (UI::Button("Copy")) {
+            Clipboard::SetAngles3(degrees);
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pP", hueRed)) {
+            degrees.x = Clipboard::GetAngles3().x;
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pY", hueGreen)) {
+            degrees.y = Clipboard::GetAngles3().y;
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pR", hueBlue)) {
+            degrees.z = Clipboard::GetAngles3().z;
+        }
+
+        UI::PopID();
+        UI::PopID();
+
+        return degrees;
+    }
+
+    nat3 AddCopyPasteNat3(const string &in label, nat3 val) {
+
+        UI::PushID(label);
+        UI::PushID("Nat3");
+
+        UI::SameLine();
+        if (UI::Button("Copy")) {
+            Clipboard::SetNat3(val);
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pX", hueRed)) {
+            val.x = Clipboard::GetNat3().x;
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pY", hueGreen)) {
+            val.y = Clipboard::GetNat3().y;
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pZ", hueBlue)) {
+            val.z = Clipboard::GetNat3().z;
+        }
+
+        UI::PopID();
+        UI::PopID();
+
+        return val;
+    }
+
+    quat AddCopyPasteQuat(const string &in label, quat val) {
+
+        UI::PushID(label);
+        UI::PushID("Quat");
+
+        UI::SameLine();
+        if (UI::Button("Copy")) {
+            Clipboard::SetQuat(val);
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pX", hueRed)) {
+            val.x = Clipboard::GetQuat().x;
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pY", hueGreen)) {
+            val.y = Clipboard::GetQuat().y;
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pZ", hueBlue)) {
+            val.z = Clipboard::GetQuat().z;
+        }
+        UI::SameLine();
+        if (UI::ButtonColored("pW", 0, 0, .2)) {
+            val.w = Clipboard::GetQuat().w;
+        }
+
+        UI::PopID();
+        UI::PopID();
+
+        return val;
+    }
+}

--- a/src/UI/Inputs.as
+++ b/src/UI/Inputs.as
@@ -1,24 +1,32 @@
 namespace UX {
+
     vec3 InputAngles3(const string &in label, vec3 angles, vec3 _default = vec3()) {
         auto d1 = MathX::ToDeg(angles);
         auto d2 = UI::InputFloat3(label, d1);
-        auto val = MathX::ToRad(d2);
         UI::SameLine();
         if (UI::Button("Reset##"+label)) {
             return _default;
         }
+
+        d2 = Clipboard::AddCopyPasteAngles3(label, d2);
+
         // check if we actually changed anything
         if (MathX::Vec3Eq(d1, d2)) return angles;
-        return val;
+
+        return MathX::ToRad(d2);
     }
 
     vec3 InputAngles3Raw(const string &in label, vec3 angles, vec3 _default = vec3()) {
-        auto val = MathX::ToRad(UI::InputFloat3(label, MathX::ToDeg(angles)));
+        auto d1 = MathX::ToDeg(angles);
+        auto d2 = UI::InputFloat3(label, d1);
         UI::SameLine();
         if (UI::Button("Reset##"+label)) {
             return _default;
         }
-        return val;
+
+        d2 = Clipboard::AddCopyPasteAngles3(label, d2);
+
+        return MathX::ToRad(d2);;
     }
 
     vec3 InputFloat3(const string &in label, vec3 val, vec3 _default = vec3()) {
@@ -27,6 +35,9 @@ namespace UX {
         if (UI::Button("Reset##"+label)) {
             return _default;
         }
+
+        ret = Clipboard::AddCopyPasteFloat3(label, ret);
+
         return ret;
     }
 
@@ -40,6 +51,9 @@ namespace UX {
         if (UI::Button("Reset##"+label)) {
             return _default;
         }
+
+        ret = Clipboard::AddCopyPasteFloat3(label, ret);
+
         return ret;
     }
 
@@ -53,12 +67,17 @@ namespace UX {
     }
 
     vec3 SliderAngles3(const string &in label, vec3 angles, float min = -180.0, float max = 180.0, const string &in format = "%.1f", vec3 _default = vec3()) {
-        auto val = MathX::ToRad(UI::SliderFloat3(label, MathX::ToDeg(angles), min, max, format));
+        auto d1 = MathX::ToDeg(angles);
+        auto d2 = UI::SliderFloat3(label, d1, min, max, format);
+        
         UI::SameLine();
         if (UI::Button("Reset##"+label)) {
             return _default;
         }
-        return val;
+
+        d2 = Clipboard::AddCopyPasteAngles3(label, d2);
+
+        return MathX::ToRad(d2);
     }
 
     vec2 SliderAngles2(const string &in label, vec2 angles, float min = -180.0, float max = 180.0, const string &in format = "%.1f", vec2 _default = vec2()) {
@@ -81,11 +100,19 @@ namespace UX {
         auto x = UI::InputInt("(X) " + label, val.x);
         auto y = UI::InputInt("(Y) " + label, val.y);
         auto z = UI::InputInt("(Z) " + label, val.z);
-        return nat3(x, y, z);
+        auto ret = nat3(x, y, z);
+
+        ret = Clipboard::AddCopyPasteNat3(label, ret);
+
+        return ret;
     }
 
     nat3 InputNat3(const string &in label, nat3 val) {
-        return Vec3ToNat3(UI::InputFloat3(label, Nat3ToVec3(val)));
+        auto ret = Vec3ToNat3(UI::InputFloat3(label, Nat3ToVec3(val)));
+
+        ret = Clipboard::AddCopyPasteNat3(label, ret);
+
+        return ret;
     }
 
     nat2 InputNat2(const string &in label, nat2 val) {
@@ -109,6 +136,9 @@ namespace UX {
         if (UI::Button("Reset##"+label)) {
             return _default;
         }
+
+        ret = Clipboard::AddCopyPasteQuat(label, ret);
+
         return ret;
     }
 


### PR DESCRIPTION
Added a Clipboard Class with support for Float3, Angles3, Nat3, and Quat. Amended calls in the Inputs class to append Clipboard methods.
![Trackmania_2024-02-28_23-07-20](https://github.com/XertroV/tm-editor-plus-plus/assets/8411750/9bf2c5a9-cd44-487c-b67b-8029fca57f2b)
