### PR TITLE
fix auto-naming custom blocks

### DIFF
--- a/src/Components/ItemEditor/IE_ItemEditorFeatures.as
+++ b/src/Components/ItemEditor/IE_ItemEditorFeatures.as
@@ -33,6 +33,9 @@ class IE_FeaturesTab : Tab {
             if (fname.ToLower().EndsWith(".item.gbx")) {
                 fname = fname.SubStr(0, fname.Length - 9);
             }
+            if (fname.ToLower().EndsWith(".block.gbx")) {
+                fname = fname.SubStr(0, fname.Length - 10);
+            }
             ieditor.ItemModel.NameE = fname;
         }
     }


### PR DESCRIPTION
The feature of editor++ to set a custom item's name to match the file name currently only accounts for and removes the .item.gbx extension. This change makes it account for blocks (.block.gbx) and remove this extension from the custom block/item's name too