### PR TITLE
Fix for 1.28.4

### DIFF
--- a/src/Components/FillBlocks/Fill.as
+++ b/src/Components/FillBlocks/Fill.as
@@ -6,7 +6,7 @@ namespace FillBlocks {
 
 
     void OnPluginLoad() {
-        AddHotkey(VirtualKey::F, true, false, false, HotkeyFunction(OnFillHotkey), "Fill Selection");
+        AddHotkey(VirtualKey::F, true, false, false, OnFillHotkey, "Fill Selection");
     }
 
     EditorRotation@ fillCursorRot;

--- a/src/Components/Inventory/Browser.as
+++ b/src/Components/Inventory/Browser.as
@@ -18,7 +18,7 @@ class InventoryMainV2Tab : Tab {
     }
 
     bool DrawWindow() override {
-        if (windowOpen) UI::SetNextWindowSize(400, Draw::GetHeight() * 3/4, UI::Cond::FirstUseEver);
+        if (windowOpen) UI::SetNextWindowSize(400, Display::GetHeight() * 3/4, UI::Cond::FirstUseEver);
         return Tab::DrawWindow();
     }
 

--- a/src/Components/Inventory/Favorites.as
+++ b/src/Components/Inventory/Favorites.as
@@ -751,7 +751,7 @@ class FavObj {
 
     void DrawList_DrawCenteredLabelText(UI::DrawList@ dl, vec2 midpoint) {
         float wrapWidth = S_IconSize.x - InvDrawVals::colGap;
-        auto nameDim = Draw::MeasureString(shortName, g_BoldFont, 14.0, wrapWidth);
+        auto nameDim = UI::MeasureString(shortName, g_BoldFont, 14.0, wrapWidth);
         auto tl = midpoint - nameDim / 2.;
         DrawList_AddTextWithStroke(dl, tl, vec4(1, 1, 1, hoverAlpha), vec4(0, 0, 0, hoverAlpha), shortName, g_BoldFont, 14.0, wrapWidth);
     }
@@ -761,10 +761,10 @@ class FavObj {
     void DrawHovered_Window() {
         vec2 mp = UI::GetMousePos();
         vec2 windowPos = vec2(
-            Draw::GetWidth() - mp.x > lastHoveredWindowDims.x + hoverBuffer
+            Display::GetWidth() - mp.x > lastHoveredWindowDims.x + hoverBuffer
                 ? mp.x + hoverBuffer
                 : mp.x - lastHoveredWindowDims.x - hoverBuffer,
-            Draw::GetHeight() - mp.y > lastHoveredWindowDims.y + hoverBuffer
+            Display::GetHeight() - mp.y > lastHoveredWindowDims.y + hoverBuffer
                 ? mp.y + hoverBuffer
                 : mp.y - lastHoveredWindowDims.y - hoverBuffer
         );

--- a/src/Components/Inventory/RefreshItems.as
+++ b/src/Components/Inventory/RefreshItems.as
@@ -312,7 +312,7 @@ class ItemEmbedTab : Tab {
             msg += tostring(Reloading_Done) + " / " + Reloading_Total
                 + Text::Format(" ( %2.1f%% ) ]", float(Reloading_Done) * 100. / Reloading_Total);
             float size = 40.;
-            auto dims = Draw::MeasureString(msg, g_BigFont, size);
+            auto dims = UI::MeasureString(msg, g_BigFont, size);
             auto tl = midPos - dims/2.;
             float pad = 20.;
             auto boxTL = tl - pad;

--- a/src/Components/ItemEditor/IE_ItemEditorFeatures.as
+++ b/src/Components/ItemEditor/IE_ItemEditorFeatures.as
@@ -45,7 +45,7 @@ class IE_FeaturesTab : Tab {
         S_UpdateItemThumbnailAfterReload = UI::Checkbox("Automatically update the items thumbnail after a reload?", S_UpdateItemThumbnailAfterReload);
         S_AutoThumbnailDirection = (UI::InputInt("Auto Thumbnail Direction", S_AutoThumbnailDirection) + 4) % 4;
         if (UI::Button("Update thumbnail and save item")) {
-            startnew(CoroutineFunc(ItemEditor::UpdateThumbnailAndSaveItem));
+            startnew(ItemEditor::UpdateThumbnailAndSaveItem);
         }
     }
 }

--- a/src/Components/Macroblocks/MacroblockOpts.as
+++ b/src/Components/Macroblocks/MacroblockOpts.as
@@ -193,7 +193,7 @@ namespace MbShowGhostFree {
         mbiToFix.MwAddRef();
         mbiWasUnassigned = mbi.Id.Value == uint(-1);
         // this will be applied after generation is done
-        Meta::StartWithRunContext(Meta::RunContext::BeforeScripts, CoroutineFunc(_Run_Fix_MacroBlock_BlockUnitCoords));
+        Meta::StartWithRunContext(Meta::RunContext::BeforeScripts, _Run_Fix_MacroBlock_BlockUnitCoords);
         dev_trace('MbShowGhostFree: Fix_MacroBlock_BlockUnitCoords_Soon called for mbi: ' + mbi.IdName);
     }
 

--- a/src/Components/Map/LightmapTab.as
+++ b/src/Components/Map/LightmapTab.as
@@ -551,7 +551,7 @@ void DrawMappingOverlay(UI::Texture@ tex, vec2 imgTL, LmMappingCache@ mapping, b
                 auto yOffset = 34.0 * nbHovered;
                 auto textTL = imgTL + vec2(1024 + 20, yOffset);
                 auto rectTL = textTL - vec2(4);
-                auto textSize = Draw::MeasureString(item.fidFileName, g_BigFont, 26);
+                auto textSize = UI::MeasureString(item.fidFileName, g_BigFont, 26);
                 auto rectSize = textSize + vec2(8);
                 fg.AddRectFilled(vec4(rectTL, rectSize), vec4(.1, .1, .1, .9));
                 DrawList_AddTextWithStroke(fg, imgTL + vec2(1024 + 20, yOffset), vec4(1, 1, 0, 1), vec4(0), item.fidFileName, g_BigFont, 26);

--- a/src/Components/Map/Map_EditProps.as
+++ b/src/Components/Map/Map_EditProps.as
@@ -1001,7 +1001,7 @@ void Map_SetDeco(CGameCtnChallenge@ map, MapDecoChoice d) {
     auto newDeco = GetDecoration(d);
     if (newDeco !is null) {
         @map.Decoration = newDeco;
-        startnew(CoroutineFuncUserdata(Map_SaveAndRevertDeco), deco);
+        startnew(Map_SaveAndRevertDeco, deco);
     }
 }
 

--- a/src/Components/NodeGraph/Node.as
+++ b/src/Components/NodeGraph/Node.as
@@ -144,7 +144,7 @@ namespace NG {
             } else {
                 label = name;
             }
-            textSize = Draw::MeasureString(label, g_NormFont, 16.);
+            textSize = UI::MeasureString(label, g_NormFont, 16.);
             auto yOff = size.y / 2. + 3.;
             if (alignRight) {
                 UI::SetCursorPos(startCur + pos - vec2(textSize.x + 8., yOff));
@@ -179,7 +179,7 @@ namespace NG {
             //     UI::AlignTextToFramePadding();
             //     string label = name + ": " + value;
             //     if (IsOutput) {
-            //         UI::Dummy(vec2(UI::GetContentRegionAvail().x - (Draw::MeasureString(label, g_NormFont, 16.) * g_scale).x - 16., 0.));
+            //         UI::Dummy(vec2(UI::GetContentRegionAvail().x - (UI::MeasureString(label, g_NormFont, 16.) * g_scale).x - 16., 0.));
             //         UI::SameLine();
             //     }
             //     UI::Text(label);
@@ -350,7 +350,7 @@ namespace NG {
 
         vec2 UIGetDrawSize() {
             if (uiDrawSize.LengthSquared() > 100.) return uiDrawSize;
-            titleBarSize = Draw::MeasureString(nodeName, g_NormFont, 16.);
+            titleBarSize = UI::MeasureString(nodeName, g_NormFont, 16.);
             titleBarSize.y += tbPadding.y * 2.;
             vec2 outputsSize = ioHeight * vec2(2., outputs.Length);
             vec2 inputsSize = ioHeight * vec2(2., inputs.Length);

--- a/src/Dev.as
+++ b/src/Dev.as
@@ -1757,6 +1757,7 @@ void CheckUnhookAllRegisteredHooks() {
 void Dev_AddToHookIndex(HookHelper@ hook) {}
 void Dev_AddToPatcherIndex(MemPatcher@ patcher) {}
 void Dev_DrawHookIndex() {}
+void Dev_DrawPatcherIndex() {}
 #else
 
 HookHelper@[] g_HookIndex;

--- a/src/Editor/Lightmap.as
+++ b/src/Editor/Lightmap.as
@@ -92,7 +92,7 @@ namespace Editor {
 
     uint GetLMDebugFlag() {
         CheckInitLMDebugFlag();
-        if (Ptr_LMDebugFlag == 0) return -1;
+        if (Ptr_LMDebugFlag == 0) return uint(-1);
         return Dev::ReadUInt32(Ptr_LMDebugFlag);
     }
 

--- a/src/Main.as
+++ b/src/Main.as
@@ -184,7 +184,7 @@ void RenderEarly() {
     if (!UserHasPermissions) return;
     if (!GameVersionSafe) return;
 
-    g_screen = vec2(Draw::GetWidth(), Draw::GetHeight());
+    g_screen = vec2(Display::GetWidth(), Display::GetHeight());
     g_stdPxToScreenPx = g_screen.y / 1440.;
     Picker::RenderEarly();
 

--- a/src/Main.as
+++ b/src/Main.as
@@ -47,7 +47,7 @@ void Main() {
 
     RegisterOnEditorStartingUpCallback(EditorPatches::OnEditorStartingUp, "EditorPatches::OnEditorStartingUp");
 
-    RegisterOnEditorStartingUpCallback(OnEditorStartingFunc(PillarsChoice::OnEditorStartingUp), "PillarsChoice::OnEditorStartingUp");
+    RegisterOnEditorStartingUpCallback(PillarsChoice::OnEditorStartingUp, "PillarsChoice::OnEditorStartingUp");
     RegisterOnEditorLoadCallback(PillarsChoice::OnEditorLoad, "PillarsChoice::OnEditorLoad");
     RegisterOnEditorUnloadCallback(PillarsChoice::OnEditorUnload, "PillarsChoice::OnEditorUnload");
     // RegisterNewBlockCallback_Private(PillarsChoice::OnBlockPlaced, "PillarsChoice::OnBlockPlaced", 0);

--- a/src/MouseToWorldPicker.as
+++ b/src/MouseToWorldPicker.as
@@ -137,5 +137,5 @@ namespace Picker {
 
 
 vec2 GetScreenVec2() {
-    return vec2(Draw::GetWidth(), Draw::GetHeight());
+    return vec2(Display::GetWidth(), Display::GetHeight());
 }

--- a/src/Tools/MaterialsList.as
+++ b/src/Tools/MaterialsList.as
@@ -8,7 +8,7 @@ class MaterialsListTab : Tab {
     }
 
     bool DrawWindow() override {
-        UI::SetNextWindowSize(450, Draw::GetHeight() / 2);
+        UI::SetNextWindowSize(450, Display::GetHeight() / 2);
         return Tab::DrawWindow();
     }
 

--- a/src/UI/UI_Main.as
+++ b/src/UI/UI_Main.as
@@ -101,7 +101,7 @@ void _UI_Main_Render() {
 
     if (showWindow) {
         vec2 size = vec2(800, 800);
-        vec2 pos = (vec2(Draw::GetWidth(), Draw::GetHeight()) - size) / 2.;
+        vec2 pos = (vec2(Display::GetWidth(), Display::GetHeight()) - size) / 2.;
         bool keepOpen = true;
         UI::SetNextWindowSize(int(size.x), int(size.y), UI::Cond::FirstUseEver);
         UI::SetNextWindowPos(int(pos.x), int(pos.y), UI::Cond::FirstUseEver);
@@ -126,7 +126,7 @@ void _UI_Main_Render() {
 
     if (!Editor::IsRefreshSafe()) {
         vec2 size = vec2(300, 120);
-        vec2 pos = (vec2(Draw::GetWidth(), Draw::GetHeight()) - size) / 2.;
+        vec2 pos = (vec2(Display::GetWidth(), Display::GetHeight()) - size) / 2.;
         pos.y = 60;
         UI::SetNextWindowSize(int(size.x), int(size.y), UI::Cond::Always);
         UI::SetNextWindowPos(int(pos.x), int(pos.y), UI::Cond::Always);
@@ -143,7 +143,7 @@ void _UI_Main_Render() {
         auto ieditor = cast<CGameEditorItem>(GetApp().Editor);
         auto imIdName = ieditor.ItemModel !is null ? ieditor.ItemModel.IdName : "⚠️ ??";
         vec2 size = vec2(340, 240);
-        vec2 pos = (vec2(Draw::GetWidth(), Draw::GetHeight()) - size) / 2.;
+        vec2 pos = (vec2(Display::GetWidth(), Display::GetHeight()) - size) / 2.;
         pos.y = 60;
         UI::SetNextWindowSize(int(size.x), int(size.y), UI::Cond::Always);
         UI::SetNextWindowPos(int(pos.x), int(pos.y), UI::Cond::Always);
@@ -164,7 +164,7 @@ void _UI_Main_Render() {
 
     if (CheckIfShowEppPluginReminder()) {
         vec2 size = vec2(300, 160);
-        vec2 pos = (vec2(Draw::GetWidth(), Draw::GetHeight()) - size) / 2.;
+        vec2 pos = (vec2(Display::GetWidth(), Display::GetHeight()) - size) / 2.;
         pos.y = 200;
         UI::SetNextWindowSize(int(size.x), int(size.y), UI::Cond::Always);
         UI::SetNextWindowPos(int(pos.x), int(pos.y), UI::Cond::Always);
@@ -183,7 +183,7 @@ void _UI_Main_Render() {
 
     if (IsInEditor && FarlandsHelper::IsCameraInFarlands() && !dismissedCamReturnToStadium) {
         vec2 size = vec2(300, 120);
-        vec2 pos = (vec2(Draw::GetWidth(), Draw::GetHeight()) - size) / 2.;
+        vec2 pos = (vec2(Display::GetWidth(), Display::GetHeight()) - size) / 2.;
         pos.y = 100;
         pos.x += 300;
         UI::SetNextWindowSize(int(size.x), int(size.y), UI::Cond::Always);

--- a/src/UI/UI_Util.as
+++ b/src/UI/UI_Util.as
@@ -59,12 +59,10 @@ void SetClipboard(const string &in msg) {
     Notify("Copied: " + msg.SubStr(0, 300));
 }
 
-funcdef bool LabeledValueF(const string &in l, const string &in v);
-
 bool ClickableLabel(const string &in label, const string &in value) {
-    return ClickableLabel(label, value, ": ");
+    return ClickableLabelBetween(label, value, ": ");
 }
-bool ClickableLabel(const string &in label, const string &in value, const string &in between) {
+bool ClickableLabelBetween(const string &in label, const string &in value, const string &in between) {
     UI::Text(label.Length > 0 ? label + between + value : value);
     if (UI::IsItemHovered(UI::HoveredFlags::None)) {
         UI::SetMouseCursor(UI::MouseCursor::Hand);
@@ -97,40 +95,40 @@ bool CopiableValue(const string &in value) {
 
 
 void LabeledValue(const string &in label, bool value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, tostring(value));
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, tostring(value));
 }
 void LabeledValue(const string &in label, uint value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, tostring(value));
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, tostring(value));
 }
 void LabeledValue(const string &in label, float value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, tostring(value));
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, tostring(value));
 }
 void LabeledValue(const string &in label, int value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, tostring(value));
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, tostring(value));
 }
 void LabeledValue(const string &in label, const string &in value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, value);
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, value);
 }
 void LabeledValue(const string &in label, vec2 &in value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, FormatX::Vec2(value));
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, FormatX::Vec2(value));
 }
 void LabeledValue(const string &in label, nat3 &in value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, FormatX::Nat3(value));
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, FormatX::Nat3(value));
 }
 void LabeledValue(const string &in label, vec3 &in value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, FormatX::Vec3(value));
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, FormatX::Vec3(value));
 }
 void LabeledValue(const string &in label, vec4 &in value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, value.ToString());
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, value.ToString());
 }
 void LabeledValue(const string &in label, int3 &in value, bool clickToCopy = true) {
-    (clickToCopy ? (CopiableLabeledValue) : LabeledValueF(ClickableLabel))(label, FormatX::Int3(value));
+    (clickToCopy ? (CopiableLabeledValue) : ClickableLabel)(label, FormatX::Int3(value));
 }
 
 
 
 bool CopiableLabeledValueTooltip(const string &in label, const string &in value) {
-    bool clicked = ClickableLabel(label, "", "");
+    bool clicked = ClickableLabelBetween(label, "", "");
     AddSimpleTooltip(value);
     if (clicked) {
         SetClipboard(value);


### PR DESCRIPTION
I don't know if you've already started working on this in the 2 hours since the version released.
But since I would like editor++ to function when the new campaign releases I've had a look at it myself
\- angelscript no longer supports creating a function/delegate of a non-method. Usually this is fine, although may be less clear, it seems the functions get auto-cast. The only exception is where in `UI_Util.as` you were using this to cast a function inside a ternary operator. This no longer works so I've had to make a larger change here, in this case renaming one function to avoid the overload. I'm hoping you're ok with this
\- renaming `Draw::MeasureString` to UI::MeasureString` and `Draw::GetWidth/Height` to `Display::GetWidth/Height`
\- fixing the existing compile issue with `Dev_DrawPatcherIndex` only being defined if `#DEV` (which was an issue already before 1.28.4)
\- removing one uint conversion warning xdd